### PR TITLE
Resolve umbrella project bugs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.1.2
-elixir 1.17.3-otp-27
+erlang 27.2
+elixir 1.18.0-otp-27

--- a/lib/exposure.ex
+++ b/lib/exposure.ex
@@ -15,7 +15,6 @@ defmodule Exposure do
 
   @snapshot_directory Application.compile_env(:exposure, :snapshot_directory, "_snapshots")
   @snapshot_test_tag Application.compile_env(:exposure, :snapshot_test_tag, :snapshot)
-  @test_paths Keyword.get(Mix.Project.config(), :test_paths, [])
 
   ################################
   # Public API
@@ -125,18 +124,31 @@ defmodule Exposure do
   end
 
   defp test_paths do
-    :persistent_term.get({__MODULE__, :test_paths})
-  rescue
-    ArgumentError ->
-      paths =
-        @test_paths
-        |> maybe_add_default_path()
-        |> Enum.map(&Path.expand/1)
-        |> Enum.sort()
-        |> Enum.reduce([], &maybe_add_test_path/2)
+    key = {__MODULE__, Mix.Project.get!(), :test_paths}
 
-      :persistent_term.put({__MODULE__, :test_paths}, paths)
-      paths
+    case fetch_test_paths(key) do
+      {:ok, paths} -> paths
+      _ -> put_test_paths(key)
+    end
+  end
+
+  defp fetch_test_paths(key) do
+    {:ok, :persistent_term.get(key)}
+  rescue
+    _ -> :error
+  end
+
+  defp put_test_paths(key) do
+    paths =
+      Mix.Project.config()
+      |> Keyword.get(:test_paths, [])
+      |> maybe_add_default_path()
+      |> Enum.map(&Path.expand/1)
+      |> Enum.sort()
+      |> Enum.reduce([], &maybe_add_test_path/2)
+
+    :persistent_term.put(key, paths)
+    paths
   end
 
   defp maybe_add_default_path([]) do

--- a/lib/exposure.ex
+++ b/lib/exposure.ex
@@ -128,14 +128,14 @@ defmodule Exposure do
 
     case fetch_test_paths(key) do
       {:ok, paths} -> paths
-      _ -> put_test_paths(key)
+      :error -> put_test_paths(key)
     end
   end
 
   defp fetch_test_paths(key) do
     {:ok, :persistent_term.get(key)}
   rescue
-    _ -> :error
+    ArgumentError -> :error
   end
 
   defp put_test_paths(key) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Exposure.MixProject do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.1.0"
 
   ################################
   # Public API
@@ -21,7 +21,7 @@ defmodule Exposure.MixProject do
       description: description(),
       dialyzer: dialyzer(),
       docs: docs(),
-      elixir: "~> 1.16",
+      elixir: "~> 1.18",
       name: "Exposure",
       package: package(),
       preferred_cli_env: preferred_cli_env(),


### PR DESCRIPTION
## Purpose

This PR aims to fix two related bugs that crop up when using this application in an umbrella project.

`Exposure` evaluates test paths at compile time in order to ensure that `Mix` is available (since test paths are configured in the mix project config). The issue here is that, in umbrella projects, tests are run in the context of the child application BUT dependencies are compiled in the context of the mix project. So, during compilation, the umbrella project test paths would be baked into the library (usually just the default `["test"]`) and the children would run their tests using those test paths. In many cases, this worked fine because, let's face it, most people aren't configuring custom test paths. However, if two children applications had different test paths, this would cause an issue.

Additionally, using `:persistent_term` to cache the test paths was also inherently flawed because it was explicitly making the assumption that test paths must be the same between children applications (by nature of the key it was using).

## Approach

This PR resolves the issue by:
1. Evaluating the test paths at runtime instead of compile time
2. Adding the mix project to the `:persistent_term` key to ensure no conflict between children applications

These changes both leverage `Mix` at runtime, but that isn't an issue because `Mix` is guaranteed to be available by nature of the fact that this library is used exclusively through the context of a mix task.

## Testing

This PR relies on the existing test suite to ensure no breaking changes. anecdotally, these changes were also tested on a personal umbrella project.